### PR TITLE
Fix Dockerfile to run npm start from website directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,21 +7,13 @@ WORKDIR /app
 # Copy the rest of the application code to the container
 COPY . .
 
-WORKDIR /app/website 
-
-# Copy the package.json and package-lock.json files to the container
-COPY package*.json ./
+WORKDIR /app/website
 
 # Install build tools
-RUN apk add --no-cache build-base krb5-dev
-RUN apk add --no-cache python3
-RUN apk add bash
+RUN apk add --no-cache build-base krb5-dev python3 bash
 
 # Install the Node.js dependencies
 RUN npm install
-
-#back to top
-WORKDIR /app
 
 # Expose the port that the web application will listen on
 EXPOSE 3000


### PR DESCRIPTION
The container was failing to serve resources because npm start was running from /app instead of /app/website where the package.json is located.

Changes:
- Remove WORKDIR /app at end so npm start runs from /app/website
- Remove redundant COPY package*.json (files already copied by COPY . .)
- Consolidate apk add commands into single layer