### PR TITLE
Fix missing bag directory creation causing file download failures

### DIFF
--- a/website/routes/index.js
+++ b/website/routes/index.js
@@ -815,6 +815,7 @@ var createSubdirs = function(master, res){
         master.pathTmpFiles = path.join(master.pathTmp, "files");
 
         // logger.info("POST: make other dirs...");
+        mkdirSync(master.pathTmpBag);
         mkdirSync(master.pathTmpZip);
         mkdirSync(master.pathTmpFiles);
         return master;


### PR DESCRIPTION
The createSubdirs function was setting pathTmpBag but not actually creating the directory. The gladstone bagit library then failed when trying to create bag/data subdirectory because the parent didn't exist.

Added mkdirSync(master.pathTmpBag) to create the bag directory along with the zip and files directories.