### PR TITLE
Add tmp directory creation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN apk add --no-cache build-base krb5-dev python3 bash
 # Install the Node.js dependencies
 RUN npm install
 
+# Create tmp directory for file processing
+RUN mkdir -p /app/website/tmp
+
 # Expose the port that the web application will listen on
 EXPOSE 3000
 


### PR DESCRIPTION
The tmp directory is required for file processing (creating LiPD files, NOAA conversions, etc.) but wasn't being created in the container. This caused mkdir operations to fail when trying to create subdirectories.