### PR TITLE
Add Flask proxy route to lipdnet app

### DIFF
--- a/website/app.js
+++ b/website/app.js
@@ -23,6 +23,7 @@ var bodyParser = require('body-parser');
 var multer = require("multer");
 var sys = require('sys');
 var favicon = require('serve-favicon');
+var { createProxyMiddleware } = require('http-proxy-middleware');
 var app = express();
 var routes = require('./routes/index');
 var users = require('./routes/users');
@@ -120,6 +121,15 @@ app.use(multer({ storage: storage, limits:{ fieldSize: 25 * 1024 * 1024 }}).sing
 // });
 
 
+
+// Proxy /flask/* requests to localhost:9023
+app.use('/flask', createProxyMiddleware({
+  target: 'http://localhost:9023',
+  changeOrigin: true,
+  pathRewrite: {
+    '^/flask': '' // Remove /flask prefix when forwarding
+  }
+}));
 
 // Attach the router to our app.
 app.use('/', routes);

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "del": "^2.0.0",
     "es6-promise": "^4.2.6",
     "express": "~4.13.1",
+    "http-proxy-middleware": "^2.0.6",
     "fast-csv": "^2.4.0",
     "forever": "^4.0.3",
     "gladstone": "0.2.4",


### PR DESCRIPTION
- Add http-proxy-middleware dependency to package.json
- Configure proxy middleware in app.js to forward /flask/* requests
- Strip /flask prefix when forwarding to target server