### PR TITLE
Fix four app stability/hygiene issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN npm install
 # Create tmp directory for file processing
 RUN mkdir -p /app/website/tmp
 
+ENV NODE_ENV=production
+
 # Expose the port that the web application will listen on
 EXPOSE 3000
 

--- a/website/app.js
+++ b/website/app.js
@@ -95,11 +95,9 @@ var storage = multer.diskStorage({
   }
 });
 
-if (port === 3000){
-  app.set("environment", "development");
-} else {
-  app.set("environment", "production");
-}
+// Trust NODE_ENV. Default to production so error responses don't leak stack
+// traces when the var is unset.
+app.set("environment", process.env.NODE_ENV === "development" ? "development" : "production");
 
 
 // view engine setup
@@ -128,6 +126,12 @@ app.use('/flask', createProxyMiddleware({
   changeOrigin: true,
   pathRewrite: {
     '^/flask': '' // Remove /flask prefix when forwarding
+  },
+  onError: function(err, req, res){
+    logger.info('flask-proxy: ' + (req && req.method) + ' ' + (req && req.url) + ' -> ' + err.code);
+    if (res && !res.headersSent){
+      res.status(502).json({error: 'Flask backend unavailable', code: err.code});
+    }
   }
 }));
 
@@ -163,10 +167,5 @@ if (app.get("environment") === 'development') {
     });
   });
 }
-
-app.listen(app.get('port'), function() {
-  logger.info('app: Node port: ', app.get('port'));
-  logger.info("app: Node Env: ", app.get("environment"));
-});
 
 module.exports = app;

--- a/website/bin/www
+++ b/website/bin/www
@@ -7,6 +7,7 @@
 var app = require('../app');
 var debug = require('debug')('gcr_proto:server');
 var http = require('http');
+var logger = require('../node_modules_custom/node_log.js');
 
 /**
  * Get port from environment and store in Express.
@@ -87,4 +88,6 @@ function onListening() {
     ? 'pipe ' + addr
     : 'port ' + addr.port;
   debug('Listening on ' + bind);
+  logger.info('app: Node port: ', app.get('port'));
+  logger.info('app: Node Env: ', app.get('environment'));
 }

--- a/website/node_modules_custom/node_stats.js
+++ b/website/node_modules_custom/node_stats.js
@@ -61,18 +61,40 @@ var loadStats = function() {
     return stats;
 };
 
-/**
- * Save stats to file
- */
-var saveStats = function(stats) {
+// Debounced async save: every recordX() flips `dirty = true`; a single timer
+// flushes to disk every SAVE_INTERVAL_MS. Replaces a per-request writeFileSync
+// of pretty-printed JSON that blocked the event loop on every page visit.
+var SAVE_INTERVAL_MS = 5000;
+var dirty = false;
+var writeInFlight = false;
+
+var saveStats = function() {
+    if (!dirty || writeInFlight) return;
+    dirty = false;
+    writeInFlight = true;
+    stats.lastUpdated = new Date().toISOString();
+    fs.writeFile(STATS_FILE, JSON.stringify(stats), function(err) {
+        writeInFlight = false;
+        if (err) {
+            dirty = true; // retry on next tick
+            logger.info('node_stats: Error saving stats file: ' + err);
+        }
+    });
+};
+
+setInterval(saveStats, SAVE_INTERVAL_MS).unref();
+
+// Flush synchronously on shutdown so we don't lose the last few events.
+var flushSyncOnExit = function() {
+    if (!dirty) return;
     try {
         stats.lastUpdated = new Date().toISOString();
-        fs.writeFileSync(STATS_FILE, JSON.stringify(stats, null, 2));
-        logger.info('node_stats: Stats saved to file');
-    } catch (err) {
-        logger.info('node_stats: Error saving stats file: ' + err);
-    }
+        fs.writeFileSync(STATS_FILE, JSON.stringify(stats));
+    } catch (err) { /* nothing useful to do during shutdown */ }
 };
+process.on('SIGTERM', flushSyncOnExit);
+process.on('SIGINT', flushSyncOnExit);
+process.on('exit', flushSyncOnExit);
 
 // In-memory stats cache
 var stats = loadStats();
@@ -177,7 +199,7 @@ var recordUpload = function(type, metadata, userIp) {
             recordUniqueUser(userIp);
         }
 
-        saveStats(stats);
+        dirty = true;
         logger.info('node_stats: Recorded ' + type + ' upload. Total: ' + stats.uploads[type].total);
     } catch (err) {
         logger.info('node_stats: Error recording upload: ' + err);
@@ -215,7 +237,7 @@ var recordDownload = function(type, metadata, userIp) {
             recordUniqueUser(userIp);
         }
 
-        saveStats(stats);
+        dirty = true;
         logger.info('node_stats: Recorded ' + type + ' download. Total: ' + stats.downloads[type].total);
     } catch (err) {
         logger.info('node_stats: Error recording download: ' + err);
@@ -263,7 +285,7 @@ var recordPageVisit = function(page, metadata, userIp) {
             recordUniqueUser(userIp);
         }
 
-        saveStats(stats);
+        dirty = true;
         logger.info('node_stats: Recorded ' + page + ' page visit. Total: ' + stats.pageVisits[page].total);
     } catch (err) {
         logger.info('node_stats: Error recording page visit: ' + err);
@@ -406,7 +428,8 @@ var getStatsByPeriod = function(period) {
 var resetStats = function() {
     stats = JSON.parse(JSON.stringify(defaultStats));
     stats.startedTracking = new Date().toISOString();
-    saveStats(stats);
+    dirty = true;
+    saveStats();
     logger.info('node_stats: Stats reset');
     return stats;
 };


### PR DESCRIPTION
## Summary

Four small, independent fixes that came out of the post-mortem on this week's outage. None of these caused the outage itself (that was a weekly host reboot + missing systemd unit, fixed separately on the production host), but they were uncovered while reading the code and are worth doing.

- **Remove orphan `app.listen()` in `app.js`.** `bin/www` already creates the real HTTP server on port 3000. The trailing `app.listen(app.get('port'), ...)` at the bottom of `app.js` ran first during `require()`, before `bin/www` had a chance to call `app.set('port', ...)`. `app.get('port')` was therefore `undefined` at that point, so `app.listen(undefined, ...)` was binding an orphan server to an OS-assigned ephemeral port inside the container. Side effect: the "Node port: 3000" boot log was lying — it came from the orphan's callback after `port` had been set asynchronously. Boot log lines were moved into `bin/www`'s `onListening` callback so the message reflects the real bound port.
- **Add `onError` to the `/flask` proxy.** `http-proxy-middleware` v2 already has default error handling, so this was never a crash risk, but the default behavior returns 504 and the error log is opaque. The new handler logs method + URL + errno and returns 502 with a clearer body when the Flask backend is unreachable.
- **Fix environment detection.** The previous heuristic in `app.js` set `environment = development` when `port === 3000`, which is unconditionally true inside the container. This activated the development error handler, which renders full stack traces to clients via `views/error.jade`. The fix is to read `NODE_ENV` directly and default to `production`. The Dockerfile now sets `NODE_ENV=production` after the `npm install` step (so any future devDependencies are still installed at build time).
- **Debounce + async the stats file writes.** `node_stats.js` was doing `fs.writeFileSync` of a pretty-printed JSON blob (currently ~1-2 MB, growing) on every page visit, upload, and download, blocking the event loop on every request and producing one `Stats saved to file` log line per request. Record functions now just set a dirty flag; a single 5s interval flushes asynchronously. `SIGTERM` / `SIGINT` / `exit` handlers do a final synchronous flush so we don't lose the last few events on shutdown. The `null, 2` pretty-print was also dropped (saves ~30% file size).

## Test plan

- [ ] Container builds locally (`docker build .`)
- [ ] Container starts and serves `GET /` with 200
- [ ] Startup log shows `Node Env:  production` (not `development`)
- [ ] Boot log line reflects the real bound port (port 3000 inside the container)
- [ ] No `Stats saved to file` line per request — instead, at most one every 5s when there is activity
- [ ] `/api/stats` endpoint still returns updated counts after a few page hits
- [ ] `playground_stats.json` is being written periodically and is well-formed JSON
- [ ] Force a 500 in a route (or trigger an existing error path) and confirm the response body does NOT include a stack trace
- [ ] With Flask backend stopped, hit `/flask/anything` and confirm a 502 + JSON body (not 504, not a stack trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)